### PR TITLE
Add support for 240×280 displays (e.g. GMT169-01)

### DIFF
--- a/Arduino_ST7789.cpp
+++ b/Arduino_ST7789.cpp
@@ -37,6 +37,21 @@ static const uint8_t PROGMEM
     ST7789_DISPON ,   ST_CMD_DELAY,  		// 9: Main screen turn on, no args, w/delay
     255 };                  				// 255 = 500 ms delay
 
+static const uint8_t PROGMEM
+  cmd_240x280[] = {
+    10,
+    ST7789_SWRESET,   ST_CMD_DELAY, 150,
+    ST7789_SLPOUT ,   ST_CMD_DELAY, 255,
+    ST7789_COLMOD , 1+ST_CMD_DELAY, 0x55, 10,
+    ST7789_MADCTL , 1, 0x00,
+    ST7789_CASET  , 4, 0x00, 0x00, 0x00, 239,
+    // RASET: start row = 20 (0x0014), end row = 299 (0x012B)
+    ST7789_RASET  , 4, 0x00, 0x14, 0x01, 0x2B,
+    ST7789_INVON ,   ST_CMD_DELAY, 10,
+    ST7789_NORON  ,   ST_CMD_DELAY, 10,
+    ST7789_DISPON ,   ST_CMD_DELAY, 255
+  };
+
 inline uint16_t swapcolor(uint16_t x) { 
   return (x << 11) | (x & 0x07E0) | (x >> 11);
 }
@@ -240,40 +255,42 @@ void Arduino_ST7789::commonInit(const uint8_t *cmdList) {
 }
 
 void Arduino_ST7789::setRotation(uint8_t m) {
-
   writecommand(ST7789_MADCTL);
-  rotation = m % 4; // can't be higher than 3
+  rotation = m % 4;
   switch (rotation) {
-   case 0:
-     writedata(ST7789_MADCTL_MX | ST7789_MADCTL_MY | ST7789_MADCTL_RGB);
+    case 0:
+      writedata(ST7789_MADCTL_MX | ST7789_MADCTL_MY | ST7789_MADCTL_RGB);
+      _xstart = _colstart;
+      _ystart = _rowstart;
+      break;
+    case 1:
+      writedata(ST7789_MADCTL_MY | ST7789_MADCTL_MV | ST7789_MADCTL_RGB);
+      _ystart = _colstart;
+      _xstart = _rowstart;
+      break;
+    case 2:
+      writedata(ST7789_MADCTL_RGB);
+      _xstart = _colstart;
+      _ystart = _rowstart;
+      break;
+    case 3:
+      writedata(ST7789_MADCTL_MX | ST7789_MADCTL_MV | ST7789_MADCTL_RGB);
+      _ystart = _colstart;
+      _xstart = _rowstart;
+      break;
+  }
 
-     _xstart = _colstart;
-     _ystart = _rowstart;
-     break;
-   case 1:
-     writedata(ST7789_MADCTL_MY | ST7789_MADCTL_MV | ST7789_MADCTL_RGB);
-
-     _ystart = _colstart;
-     _xstart = _rowstart;
-     break;
-  case 2:
-     writedata(ST7789_MADCTL_RGB);
- 
-     _xstart = _colstart;
-     _ystart = _rowstart;
-     break;
-
-   case 3:
-     writedata(ST7789_MADCTL_MX | ST7789_MADCTL_MV | ST7789_MADCTL_RGB);
-
-     _ystart = _colstart;
-     _xstart = _rowstart;
-     break;
+  if (rotation & 1) {
+    // 90° или 270°
+    Adafruit_GFX::_width  = _physical_height;
+    Adafruit_GFX::_height = _physical_width;
+  } else {
+    Adafruit_GFX::_width  = _physical_width;
+    Adafruit_GFX::_height = _physical_height;
   }
 }
 
-void Arduino_ST7789::setAddrWindow(uint8_t x0, uint8_t y0, uint8_t x1,
- uint8_t y1) {
+void Arduino_ST7789::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
 
   uint16_t x_start = x0 + _xstart, x_end = x1 + _xstart;
   uint16_t y_start = y0 + _ystart, y_end = y1 + _ystart;
@@ -450,12 +467,21 @@ inline void Arduino_ST7789::DC_LOW(void) {
 void Arduino_ST7789::init(uint16_t width, uint16_t height) {
   commonInit(NULL);
 
-  _colstart = ST7789_240x240_XSTART;
-  _rowstart = ST7789_240x240_YSTART;
-  _height = 240;
-  _width = 240;
+  _physical_width  = width;
+  _physical_height = height;
 
-  displayInit(cmd_240x240);
+  Adafruit_GFX::_width  = width;
+  Adafruit_GFX::_height = height;
+
+  if (width == 240 && height == 280) {
+    _colstart = 0;
+    _rowstart = 20;
+    displayInit(cmd_240x280);
+  } else {
+    _colstart = 0;
+    _rowstart = 0;
+    displayInit(cmd_240x240);
+  }
 
   setRotation(2);
 }

--- a/Arduino_ST7789.h
+++ b/Arduino_ST7789.h
@@ -92,7 +92,7 @@ class Arduino_ST7789 : public Adafruit_GFX {
   Arduino_ST7789(int8_t DC, int8_t RST, int8_t SID, int8_t SCLK, int8_t CS = -1);
   Arduino_ST7789(int8_t DC, int8_t RST, int8_t CS = -1);
 
-  void     setAddrWindow(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1),
+  void     setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1),
            pushColor(uint16_t color),
            fillScreen(uint16_t color),
            drawPixel(int16_t x, int16_t y, uint16_t color),
@@ -124,6 +124,9 @@ class Arduino_ST7789 : public Adafruit_GFX {
   boolean  _hwSPI;
 
   int8_t  _cs, _dc, _rst, _sid, _sclk;
+
+  uint16_t _physical_width;
+  uint16_t _physical_height;
 
 #if defined(USE_FAST_IO)
   volatile RwReg  *dataport, *clkport, *csport, *dcport;


### PR DESCRIPTION
## Description

This PR adds proper support for ST7789-based displays with a resolution of **240×280 pixels** (such as the GMT169-01 module). Previously, the library was hard‑coded for 240×240 panels and could not correctly drive the larger displays – graphics were clipped or only part of the screen was used.

The changes are backward‑compatible: existing 240×240 displays continue to work without any modification.

## Key Changes

1. **New initialisation array `cmd_240x280[]`**  
   - Sets column range (`CASET`) to 0…239 (same as 240×240).  
   - Sets row range (`RASET`) to 20…299, because the ST7789’s internal RAM is 240×320 and the 280‑pixel active area is centred vertically (20 lines are unused at the top/bottom).  
   - All other commands (colour mode, inversion, etc.) are identical to the 240×240 sequence.

2. **Extended coordinate range in `setAddrWindow`**  
   - Changed the argument types from `uint8_t` to `uint16_t` to allow Y‑coordinates up to 279 (values > 255). This is essential for drawing anywhere on a 280‑pixel tall display.

3. **Physical size tracking for correct rotation**  
   - Added private members `_physical_width` and `_physical_height` to remember the actual panel dimensions.  
   - Modified `setRotation()` to swap width and height based on these physical values, ensuring that after a rotation the logical dimensions match the physical orientation of the display.

4. **Conditional offset in `init()`**  
   - When `init(240, 280)` is called, `_rowstart` is set to **20** and the new initialisation table is used.  
   - For any other resolution (including 240×240) the traditional offset `_rowstart = 0` and the old table `cmd_240x240[]` are applied, preserving compatibility.

## Testing

The modified library has been tested with:
- **Raspberry Pi Pico (RP2040)** board.
- **240×280** displays (GMT169-01) – full screen is now correctly addressed, `fillScreen()` works, and rotations behave as expected.

Test sketch from the examples folder run successfully.

---

Please let me know if any further adjustments are needed. I hope these changes can be merged to benefit other users with similar displays.